### PR TITLE
Add kwsk01

### DIFF
--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -119,6 +119,10 @@ http {
       proxy_pass http://tokyurubykaigi.github.io;
     }
 
+    location ~ ^/kwsk01(.*) {
+      proxy_pass http://kawasakirb.github.io;
+    }
+
     # regional.rubykairi.org
     location / {
       proxy_pass http://regional-gh.rubykaigi.org;


### PR DESCRIPTION
> 川崎Ruby会議01(kwsk01)のページへの転送設定を追加させて下さい。
> 転送先: http://kawasakirb.github.io/kwsk01/

こんな感じで kawasakirb/rko-router kwsk01 から ruby-no-kai/rko-router master へプルリクするつもりです。
